### PR TITLE
Fix for uglification failure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,7 @@ grunt.initConfig({
 				sort: true,
 				toplevel: true
 			},
-			compress: true,
+			compress: {},
 			preserveComments: false
 		},
         core: {


### PR DESCRIPTION
Somebody else had this same problem (https://github.com/shieldui/shieldui-lite/pull/2), but apparently the pull request didn't make it in to the official repository, so I've applied it.

Without this fix, expect the following error:

```
Running "uglify:core" (uglify) task
TypeError: Cannot create property 'warnings' on boolean 'true'
    at Object.exports.minify (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt-contrib-uglify/tasks/lib/uglify.js:65:35)
    at /Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt-contrib-uglify/tasks/uglify.js:106:25
    at Array.forEach (native)
    at Object.<anonymous> (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt-contrib-uglify/tasks/uglify.js:36:16)
    at Object.<anonymous> (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt/lib/grunt/task.js:264:15)
    at Object.thisTask.fn (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt/lib/grunt/task.js:82:16)
    at Object.<anonymous> (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt/lib/util/task.js:301:30)
    at Task.runTaskFn (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt/lib/util/task.js:251:24)
    at Task.<anonymous> (/Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt/lib/util/task.js:300:12)
    at /Users/tadhunt/Documents/Personal/go/src/github.com/shieldui/shieldui-lite/node_modules/grunt/lib/util/task.js:227:11
>> Uglifying source "dist/js/core.js,dist/js/data.js,dist/js/util.js" failed.
Warning: Uglification failed.
Cannot create property 'warnings' on boolean 'true'. 
 Use --force to continue.

Aborted due to warnings.
```
